### PR TITLE
Fix the event listener so it no longer uses spark ballistic shield category for all shields

### DIFF
--- a/WotCBallisticShields/Src/WotCBallisticShields/Classes/X2EventListener_Shields.uc
+++ b/WotCBallisticShields/Src/WotCBallisticShields/Classes/X2EventListener_Shields.uc
@@ -39,8 +39,10 @@ static function EventListenerReturn ListenerEventFunction(Object EventData, Obje
 	{
 	case 'shield':
 		Tuple.Data[0].s = class'XGLocalizedData_BallisticShields'.default.m_strShieldCategory;
+		return ELR_NoInterrupt;
 	case 'spark_shield':
 		Tuple.Data[0].s = class'XGLocalizedData_BallisticShields'.default.m_strSparkShieldCategory;
+		return ELR_NoInterrupt;
 	default:
 		return ELR_NoInterrupt;
 	}


### PR DESCRIPTION
My bad, when I originally implemented this change, I forgot to add return/break out of the `switch()` statement, so the spark shield category name was used for all shields. This PR fixes it. Sorry.